### PR TITLE
add instant to rfc1123 serializer for rss feeds

### DIFF
--- a/server/src/main/java/org/obis/smalldata/rss/InstantRfc1123Serializer.java
+++ b/server/src/main/java/org/obis/smalldata/rss/InstantRfc1123Serializer.java
@@ -1,0 +1,36 @@
+package org.obis.smalldata.rss;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+class InstantRfc1123Serializer extends StdSerializer<Instant> {
+  private static final long serialVersionUID = 1L;
+
+  public InstantRfc1123Serializer() {
+    this(null);
+  }
+
+  public InstantRfc1123Serializer(Class<Instant> t) {
+    super(t);
+  }
+
+  @Override
+  public void serialize(Instant value, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException {
+    jgen.writeString(
+        DateTimeFormatter.RFC_1123_DATE_TIME.format(
+            ZonedDateTime.ofInstant(value, ZoneOffset.UTC)));
+  }
+
+  public static Module asJacksonMapperModule(Class c) {
+    return new SimpleModule().addSerializer(c, new InstantRfc1123Serializer());
+  }
+}

--- a/server/src/main/java/org/obis/smalldata/rss/RssGenerator.java
+++ b/server/src/main/java/org/obis/smalldata/rss/RssGenerator.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import org.obis.smalldata.rss.xmlmodel.RssFeed;
 
 public class RssGenerator {
@@ -21,6 +22,7 @@ public class RssGenerator {
     xmlMapper
         .findAndRegisterModules()
         .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    xmlMapper.registerModule(InstantRfc1123Serializer.asJacksonMapperModule(Instant.class));
     xmlMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     xmlMapper.setDefaultUseWrapper(false);
   }

--- a/server/src/test/resources/rss/rss.xml
+++ b/server/src/test/resources/rss/rss.xml
@@ -5,16 +5,16 @@
     <link>http://localhost</link>
     <description>some description</description>
     <language>nl-BE</language>
-    <lastBuildDate>2019-02-22T17:18:56.127701Z</lastBuildDate>
+    <lastBuildDate>Fri, 22 Feb 2019 17:18:56 GMT</lastBuildDate>
     <generator>IOBIS SmallData Generator</generator>
     <atom:link rel="self" type="application/rss+xml" href="http://ipt.iobis.org/training/rss.do"/>
     <item>
-      <pubDate>2019-02-22T17:18:56.127535Z</pubDate>
+      <pubDate>Fri, 22 Feb 2019 17:18:56 GMT</pubDate>
       <guid isPermaLink="false">http://ipt.iobis.org/training/resource/daily</guid>
       <ipt:dwca>http://ipt.iobis.org/training/resource/daily</ipt:dwca>
     </item>
     <item>
-      <pubDate>2019-02-22T17:18:56.127666Z</pubDate>
+      <pubDate>Fri, 22 Feb 2019 17:18:56 GMT</pubDate>
       <guid isPermaLink="false">http://ipt.iobis.org/training/resource?id=test-kurt2/v1.0</guid>
       <ipt:dwca>http://ipt.iobis.org/training/resource?id=test-kurt2/v1.0</ipt:dwca>
     </item>


### PR DESCRIPTION
using rfc1123 for dates is compliant with rss. Rss also allows for
2-digit years, but not used in this case.